### PR TITLE
Recepción de datos por el puerto USB y conversión a datos enteros

### DIFF
--- a/Python_Interface/Interface.py
+++ b/Python_Interface/Interface.py
@@ -35,9 +35,9 @@ class Program(QtWidgets.QMainWindow):
         self.Image_Array = []
 
         # Temporizador para obtener los datos del puerto Serial
-        #self.tiempo2 = QTimer()
-        #self.tiempo2.setInterval(1)
-        #self.tiempo2.timeout.connect(self.Get_Data)
+        self.tiempo2 = QTimer()
+        self.tiempo2.setInterval(1)
+        self.tiempo2.timeout.connect(self.Process_Serial_data)
         #___________________________________________________
 
         self.thread_control = None
@@ -219,6 +219,7 @@ class Program(QtWidgets.QMainWindow):
             self.Run_thread = True
             self.thread_control = threading.Thread(target=self.Thread_data_control)
             self.thread_control.start()
+            self.tiempo2.start()
 
     """
                Fin de metodo conectar serial.
@@ -239,9 +240,7 @@ class Program(QtWidgets.QMainWindow):
     def Thread_data_control(self):
         while(self.Run_thread):
             self.data = self.Serial_data.Get_serial_data()
-            self.ui.Serial_Informmation.setText(str(self.data[0]))
-            if(self.data[0]=='Ok'):
-                pass
+
                 #self.Send_image()
                 #self.Run_thread = False
 
@@ -304,6 +303,15 @@ class Program(QtWidgets.QMainWindow):
             m = m + 64
             print(k)
             """
+
+    def Process_Serial_data(self):
+        if (self.Serial_state):
+            if(self.data):
+                self.ui.Serial_Informmation.setText(str(self.data[0]))
+                if (self.data[0] == 'Ok'):
+                    a = '2234'.encode('utf_8')
+                    self.Serial_data.Serial_port.write(a)
+
 
     def Memory_commands(self, command):
         a = command.encode('utf_8')

--- a/Python_Interface/Interface.py
+++ b/Python_Interface/Interface.py
@@ -309,8 +309,10 @@ class Program(QtWidgets.QMainWindow):
             if(self.data):
                 self.ui.Serial_Informmation.setText(str(self.data[0]))
                 if (self.data[0] == 'Ok'):
-                    a = '2234'.encode('utf_8')
+                    print("Hola")
+                    a = '064-123-423'.encode('utf_8')
                     self.Serial_data.Serial_port.write(a)
+                    self.data = None
 
 
     def Memory_commands(self, command):

--- a/main.c
+++ b/main.c
@@ -42,17 +42,29 @@ char memory_buffer[256];
 uint8_t i;
 uint8_t numBytesRead;
 uint8_t control_page =0;
+int testi=0;
 int date =0;
 
+typedef struct
+{
+    int width;
+    uint8_t height;
+    int size;
+    
+    
+    
+}Image_data;
 
 
+Image_data Control_Image;
 
-                    
+
 
                     
 void Processing_Data(uint8_t Data[])
 {
-    
+    uint8_t idx=0;
+    char String_Buffer[];//Buffer to print char in the display
          
          //Clear Display Command, String = clc
         if(Data[0]==99 && Data[1]==108 && Data[2]==99)
@@ -130,33 +142,62 @@ void Processing_Data(uint8_t Data[])
         byte_control = getsUSBUSART(readBuffer, sizeof(readBuffer));
         
       
-       if(byte_control > 0 && byte_control==64)
+       if(byte_control > 0 && byte_control==4)
        { 
+            sprintf(String_Buffer, "%c", readBuffer[0]);  
+          ST7735S_Print_String(Blue_Color, String_Buffer, 0, 0, 2);
+          
+             sprintf(String_Buffer, "%c", readBuffer[1]);  
+          ST7735S_Print_String(Blue_Color, String_Buffer, 0, 20, 2);
+          
+             sprintf(String_Buffer, "%c", readBuffer[2]);  
+          ST7735S_Print_String(Blue_Color, String_Buffer, 0, 40, 2);
+          
+             sprintf(String_Buffer, "%c", readBuffer[3]);  
+          ST7735S_Print_String(Blue_Color, String_Buffer, 0, 60, 2);
+             
             
-           
-            if(control_page<4)   
-            {
-            for(i=0; i<byte_control; i++)
-            {  
-                CCS_ST7735 = 0;
-                 __delay_us(1);
-             write_color(readBuffer[i]);             
-               __delay_ms(1);
-             memory_buffer[(control_page * 64) + i] = readBuffer[i];
-             
-            }
-            control_page = control_page+1;
-            }
-            if(control_page==4)
-            {
-                CCS_ST7735 = 1;
-                 __delay_ms(1);
-                Write_Page_Program(AddressMemory, PAGE_SIZE, memory_buffer);
-             
-                CCS_Memory = 1;
-                 AddressMemory.address += 0x000100;
-                 control_page=0;
-            }
+//            while(readBuffer[idx] != '\0' )
+//            { 
+//                if(readBuffer[idx] >= '0' && readBuffer[idx]<='9')
+//                {
+//           testi = testi *10 + (readBuffer[idx] - '0');
+//          
+//          idx++;
+//            }
+//                else{
+//                    
+//                    break;
+//                }
+//                 sprintf(String_Buffer, "%d", testi);  
+//          ST7735S_Print_String(Blue_Color, String_Buffer, 0, 40, 2);
+//           CCS_ST7735 = 1;
+//                
+//            }
+       
+//            if(control_page<4)   
+//            {
+//            for(i=0; i<byte_control; i++)
+//            {  
+//                CCS_ST7735 = 0;
+//                 __delay_us(1);
+//             write_color(readBuffer[i]);             
+//               __delay_ms(1);
+//             memory_buffer[(control_page * 64) + i] = readBuffer[i];
+//             
+//            }
+//            control_page = control_page+1;
+//            }
+//            if(control_page==4)
+//            {
+//                CCS_ST7735 = 1;
+//                 __delay_ms(1);
+//                Write_Page_Program(AddressMemory, PAGE_SIZE, memory_buffer);
+//             
+//                CCS_Memory = 1;
+//                 AddressMemory.address += 0x000100;
+//                 control_page=0;
+//            }
              
             
             }
@@ -266,12 +307,18 @@ void Get_USB_Data()
 MAIN_RETURN main(void)
 {
     
+    
+    
+    Control_Image.width =0;
+Control_Image.height =0;
+Control_Image.size =0;
+    
      AddressMemory.address = 0x000000;
       MemoryID test;
       test.manufacturer = 0;
       test.memory_type = 0;
       test.capacity = 0;
-      char String_Buffer[];//Buffer to print char in the display
+      
       
  
     SYSTEM_Initialize(SYSTEM_STATE_USB_START);

--- a/main.c
+++ b/main.c
@@ -19,9 +19,17 @@ please contact mla_licensing@microchip.com
 
 /** INCLUDES *******************************************************/
 
+
+#define _STDIO_H    // 
+#define _STDLIB_H   // 
+
 #include "system.h"
 #include "Spi_Interface.h" 
-#include <stdio.h>
+
+
+#include <stdlib.h>
+
+#include <string.h>
 #include "app_device_cdc_basic.h"
 #include "app_led_usb_status.h"
 
@@ -36,12 +44,16 @@ please contact mla_licensing@microchip.com
 AddressBytes AddressMemory;
 
 static  unsigned char readBuffer[CDC_DATA_OUT_EP_SIZE];
+
+
+
 static uint8_t writeBuffer[CDC_DATA_IN_EP_SIZE];
 char memory_buffer[256];
 
 uint8_t i;
 uint8_t numBytesRead;
 uint8_t control_page =0;
+
 int testi=0;
 int date =0;
 
@@ -58,13 +70,50 @@ typedef struct
 
 Image_data Control_Image;
 
-
+void Process_Command(unsigned char *buffer)
+{
+    char dataprint[];
+    char grupo1[4], grupo2[4], grupo3[4];
+    
+   
+    for(i=0; i<=2; i++)
+    {
+        grupo1[i]= buffer[i];
+        grupo2[i]= buffer[4+i];
+        grupo3[i]= buffer[8+i];
+    }
+    
+    grupo1[3] = '\0';
+    grupo2[3] = '\0';
+    grupo3[3] = '\0';
+ 
+    
+    Control_Image.width = atoi(grupo1);
+    Control_Image.height = atoi(grupo2);
+    Control_Image.size = atoi(grupo3);
+    
+           sprintf(dataprint, "%d", Control_Image.width);  
+          ST7735S_Print_String(Blue_Color, dataprint, 0, 0, 2);
+          
+           sprintf(dataprint, "%d", Control_Image.height);  
+          ST7735S_Print_String(Blue_Color, dataprint, 0, 40, 2);
+          
+           sprintf(dataprint, "%d", Control_Image.size);  
+          ST7735S_Print_String(Blue_Color, dataprint, 0, 60, 2);
+    
+ 
+    
+  
+    
+    
+}
 
                     
 void Processing_Data(uint8_t Data[])
 {
     uint8_t idx=0;
-    char String_Buffer[];//Buffer to print char in the display
+     char String_Buffer[];//Buffer to print char in the display
+   
          
          //Clear Display Command, String = clc
         if(Data[0]==99 && Data[1]==108 && Data[2]==99)
@@ -142,21 +191,10 @@ void Processing_Data(uint8_t Data[])
         byte_control = getsUSBUSART(readBuffer, sizeof(readBuffer));
         
       
-       if(byte_control > 0 && byte_control==4)
+       if(byte_control > 0)
        { 
-            sprintf(String_Buffer, "%c", readBuffer[0]);  
-          ST7735S_Print_String(Blue_Color, String_Buffer, 0, 0, 2);
-          
-             sprintf(String_Buffer, "%c", readBuffer[1]);  
-          ST7735S_Print_String(Blue_Color, String_Buffer, 0, 20, 2);
-          
-             sprintf(String_Buffer, "%c", readBuffer[2]);  
-          ST7735S_Print_String(Blue_Color, String_Buffer, 0, 40, 2);
-          
-             sprintf(String_Buffer, "%c", readBuffer[3]);  
-          ST7735S_Print_String(Blue_Color, String_Buffer, 0, 60, 2);
-             
-            
+          ST7735S_Fill_display(Orange_Color);  
+          Process_Command(readBuffer); 
 //            while(readBuffer[idx] != '\0' )
 //            { 
 //                if(readBuffer[idx] >= '0' && readBuffer[idx]<='9')


### PR DESCRIPTION
Se ha añadido función para obtener datos enteros a partir de una string enviada desde la interfaz, ahora con estos datos se puede escribir en la memoria flash de acuerdo al tipo y la dimensión.

