### PR TITLE
Envió de datos a través de la interfaz al hardware confirmado

### DIFF
--- a/Python_Interface/Interface.py
+++ b/Python_Interface/Interface.py
@@ -6,7 +6,7 @@ from PyQt5.QtWidgets import QFileDialog
 from PyQt5.QtCore import QTimer
 from PIL import Image
 import time
-
+from image import *
 from Serial_server import *
 import numpy as np
 import threading
@@ -201,7 +201,10 @@ class Program(QtWidgets.QMainWindow):
                         g_6_bits = (Green >> 2) & 0x3F
                         b_5_bits = (Blue >> 3) & 0x1F
                         Final_value = (r_5_bits << 11) | (g_6_bits << 5) | b_5_bits
+
                         self.Image_matrix.append(Final_value)
+                print(self.Image_matrix)
+
 
         else:
             print("se debe avisar en la interfaz que no hay imagenes para procesar")
@@ -351,9 +354,11 @@ class Program(QtWidgets.QMainWindow):
                     #Si el hardware responde Ok despues de enviar el comando
                     #pimg el software responde con el numero de imagenes a enviar
                     self.ui.Serial_Informmation.setText(str(self.data[0]))
-                    a = str(len(self.Image_Array)).encode('utf_8')
+                    b = "064-092-023"
+                    a = b.encode('utf_8')  # Put Image Command
                     self.Serial_data.Serial_port.write(a)
                     self.data = None
+                    print(a)
 
                 elif(self.data and self.data[0] == 'wait'):
                     self.data = None
@@ -366,7 +371,7 @@ class Program(QtWidgets.QMainWindow):
 
                         print(metada)
                         a =  metada.encode('utf_8')
-                        time.sleep(1)
+
                         self.Serial_data.Serial_port.write(a)
 
 
@@ -375,8 +380,27 @@ class Program(QtWidgets.QMainWindow):
 
                 elif(self.data and self.data[0] == "Ready"):
                     self.ui.Serial_Informmation.setText(str(self.data[0]))
-                    a = 'cr'.encode('utf_8')
-                    self.Serial_data.Serial_port.write(a)
+                    print("Docito")
+
+                    Buffer_Data = []
+                    n = 0
+                    m = 64
+                    for j in range(0, len(img3)):
+                        decimal = img3[j]
+                        # Se separan los bytes del color al ser de 16bit
+                        # se saca la parte alta y la parte baja
+                        high_byte = int(decimal >> 8)
+                        low_byte = int(decimal & 255)
+
+                        # Se agregan los datos al buffer
+                        Buffer_Data.append(high_byte)
+                        Buffer_Data.append(low_byte)
+
+                    for k in range(0, 184):
+                        x = Buffer_Data[n:m]
+                        self.Serial_data.Serial_port.write(x)
+                        n = n + 64
+                        m = m + 64
 
 
                 elif(self.data and self.data[0] == "Okt"):

--- a/Python_Interface/Interface.py
+++ b/Python_Interface/Interface.py
@@ -44,6 +44,9 @@ class Program(QtWidgets.QMainWindow):
         self.thread_control = None
         self.Run_thread = False
 
+        #variable para guardar los metadatos de las imagenes en forma de diccionario
+        self.Image_metadata = None
+
         """
         Configuracion de los WidGets ComboBox
         
@@ -86,6 +89,7 @@ class Program(QtWidgets.QMainWindow):
         self.ui.Import_Image_button.clicked.connect(self.Import_Images)
         #Boton para procesar datos de las matrices de las imagenes
         self.ui.ProcessImg_button.clicked.connect(lambda: self.Pixel_Converter(self.Image_Array))
+        self.ui.Send_Image.clicked.connect(lambda: self.Send_image())
 
         #Connect Serial button with the function to connect with the hardware
         self.ui.Connect_Serial.clicked.connect(
@@ -163,7 +167,7 @@ class Program(QtWidgets.QMainWindow):
 
     def Pixel_Converter(self, Pixels):
         #Diccionario para guardar los metadatos de las imagenes y avisar al hardware
-        image_data = {"width" : 0, "height" : 0, "size" : 0}
+        self.Image_metadata = {"width" : 0, "height" : 0, "size" : 0}
         if len(Pixels)!=0:#Si pixels realmente contiene imagenes
             """
             
@@ -174,9 +178,9 @@ class Program(QtWidgets.QMainWindow):
             """
             for t in range(0, len(Pixels)):
                 alto, ancho, _ = Pixels[t].shape
-                image_data["width"] = ancho
-                image_data["height"] = alto
-                image_data["size"] = int((alto * ancho)/256)
+                self.Image_metadata["width"] = ancho
+                self.Image_metadata["height"] = alto
+                self.Image_metadata["size"] = int((alto * ancho)/256)
                 current_img = Pixels[t]
                 """
                 se itera en cada uno de los pixeles y se convierte en 
@@ -271,6 +275,19 @@ class Program(QtWidgets.QMainWindow):
 
 
     def Send_image(self):
+        if(self.Image_metadata and self.Serial_state):#Si hay metadatos elegidos y el puerto esta conectado
+            a = 'pimg'.encode('utf_8')#Se envia el comando Pimg para poner imagenes
+            self.Serial_data.Serial_port.write(a)
+            print("hola mundo")
+
+        else:
+            return
+
+
+
+
+
+        """
         Buffer_Data = []
         for j in range(0, len(self.Image_matrix)):
             decimal = (self.Image_matrix[j])
@@ -290,13 +307,14 @@ class Program(QtWidgets.QMainWindow):
             self.Serial_data.Serial_port.write(x)
             n = n + 64
             m = m + 64
-
+"""
 
     def Send_test_data(self):
         a = 'Test'.encode('utf_8')
         self.Serial_data.Serial_port.write(a)
         # Put Image Command
-        """
+
+        """"
         Buffer_Data = []
         n = 0
         m = 64
@@ -325,7 +343,7 @@ class Program(QtWidgets.QMainWindow):
 
                 if (self.data and self.data[0] == 'Ok'):
                     self.ui.Serial_Informmation.setText(str(self.data[0]))
-                    a = '064-123-423'.encode('utf_8')
+                    a = str(len(self.Image_Array)).encode('utf_8')
                     self.Serial_data.Serial_port.write(a)
                     self.data = None
                 if(self.data and self.data[0] == "Ready"):

--- a/Python_Interface/Interface.py
+++ b/Python_Interface/Interface.py
@@ -309,10 +309,11 @@ class Program(QtWidgets.QMainWindow):
             if(self.data):
                 self.ui.Serial_Informmation.setText(str(self.data[0]))
                 if (self.data[0] == 'Ok'):
-                    print("Hola")
                     a = '064-123-423'.encode('utf_8')
                     self.Serial_data.Serial_port.write(a)
                     self.data = None
+                if(self.data[0] == "Ready"):
+                    pass
 
 
     def Memory_commands(self, command):

--- a/Python_Interface/Interface.py
+++ b/Python_Interface/Interface.py
@@ -215,6 +215,12 @@ class Program(QtWidgets.QMainWindow):
         self.Serial_data = Serial_data(port, baudrate)
         Port_State, self.Serial_state = self.Serial_data.Connect_Port()
         self.ui.Serial_Informmation.setText("Port {},  {}".format(port, Port_State))
+
+
+        """
+        Si el puerto serial esta conectado se inicia el hilo para la recepsion sin 
+        perdida de datos 
+        """
         if(self.Serial_state):
             self.Run_thread = True
             self.thread_control = threading.Thread(target=self.Thread_data_control)
@@ -312,8 +318,9 @@ class Program(QtWidgets.QMainWindow):
                     a = '064-123-423'.encode('utf_8')
                     self.Serial_data.Serial_port.write(a)
                     self.data = None
-                if(self.data[0] == "Ready"):
-                    pass
+                if(self.data and self.data[0] == "Ready"):
+                    a = 'cr'.encode('utf_8')
+                    self.Serial_data.Serial_port.write(a)
 
 
     def Memory_commands(self, command):

--- a/Python_Interface/Interface.py
+++ b/Python_Interface/Interface.py
@@ -40,6 +40,7 @@ class Program(QtWidgets.QMainWindow):
         self.tiempo2.timeout.connect(self.Process_Serial_data)
         #___________________________________________________
 
+        #Variables para el control de hilos
         self.thread_control = None
         self.Run_thread = False
 
@@ -119,9 +120,11 @@ class Program(QtWidgets.QMainWindow):
             "Select Files",
             r"C:/images/",
             "Images (*.png *.jpg)")
-        if filenames:
+        if filenames:#Si hay archivos elegidos por el usuario
             for i in range(0, len(filenames)):
                 self.images.append(QPixmap(filenames[i]))
+
+            #Se crea un diccionario con los Labels de la interfaz.
             label_mapping = {
                 0: self.ui.Image1_Label,
                 1: self.ui.Image2_Label,
@@ -130,6 +133,9 @@ class Program(QtWidgets.QMainWindow):
                 4: self.ui.Image5_Label,
                 5: self.ui.Image6_Label,
             }
+
+            #Se itera en la lista de imagenes y se ponen los respectivos indices
+            #en los labels
             for idx, image in enumerate(self.images):
                 if idx in label_mapping:
                     label_mapping[idx].setPixmap(image)
@@ -139,45 +145,43 @@ class Program(QtWidgets.QMainWindow):
                 self.Image_Array.append(np.array(image))
             print(len(self.Image_Array))
 
-            """
-            mi_image = QPixmap(filenames[0])
-            self.ui.Image1_Label.setScaledContents(True)
-            self.ui.Image1_Label.setPixmap(mi_image)
-            image = Image.open(filenames[0])
-            pixeles = np.array(image)
-            self.Pixel_Converter(pixeles)
-            
-            
-            
-         
-            print(len(self.images))
-
-   
-              Fin funcion importar imagenes
-
-              """
-
-
-
+    # ______________________________________________________________________
 
     """
         Funcion para convertir los pixeles de color en formato de 16bits
         aun se pueden observar perdidas de color en la conversion
         la funcion guarda los valores de 16bits por pixel en la matrix
         Image_matrix, el codigo aun se encuentra en pruebas.
+        
+         Parametros :
+
+               Pixels contiene la lista de array numpy de cada una de las 
+               imagenes
+
 
         """
 
     def Pixel_Converter(self, Pixels):
+        #Diccionario para guardar los metadatos de las imagenes y avisar al hardware
         image_data = {"width" : 0, "height" : 0, "size" : 0}
-        list_data_img = []
-        if len(Pixels)!=0:
+        if len(Pixels)!=0:#Si pixels realmente contiene imagenes
+            """
+            
+            Se itera en el numero de imagenes en en la variable array Pixels
+            se obtione los metadatos de cada imagen
+            ancho, alto y produndida
+    
+            """
             for t in range(0, len(Pixels)):
                 alto, ancho, _ = Pixels[t].shape
                 image_data["width"] = ancho
                 image_data["height"] = alto
                 image_data["size"] = int((alto * ancho)/256)
                 current_img = Pixels[t]
+                """
+                se itera en cada uno de los pixeles y se convierte en 
+                formato de color de 16bits R5G6B5
+                """
                 for j in range(0, ancho):
                     for i in range(0, alto):
                         Red = int(current_img[i, j, 0])
@@ -189,29 +193,20 @@ class Program(QtWidgets.QMainWindow):
                         Final_value = (r_5_bits << 11) | (g_6_bits << 5) | b_5_bits
                         self.Image_matrix.append(Final_value)
 
-                print(len(self.Image_matrix))
+        else:
+            print("se debe avisar en la interfaz que no hay imagenes para procesar")
 
 
 
 
-        """
-        print(alto)
-        print(ancho)
-        
 
-               # print(Red, Green, Blue)
-              #  print("Red {} Green {}  Blue {}".format(r_5_bits, g_6_bits, b_5_bits))
-              #  print("Red {} Green {}  Blue {}".format(bin(r_5_bits), bin(g_6_bits), bin(b_5_bits)))
-                
-      #  print(self.Image_matrix)
-        print("Imagen Procesada")
-    """
 
     """
                 Fin del metodo conversion de pixeles
 
                 """
 
+#______________________________________________________________________
 
     """
            Funcion para conectar el puerto Serial
@@ -226,6 +221,8 @@ class Program(QtWidgets.QMainWindow):
            """
 
     def Connect_Serial(self, port, baudrate):
+        #Se conecta al puerto serial, si la conexion no es Ok
+        #Se menciona en la interfaz
         #print("Puerto {}   Baudrate {}".format(port, baudrate))
         self.Serial_data = Serial_data(port, baudrate)
         Port_State, self.Serial_state = self.Serial_data.Connect_Port()
@@ -275,8 +272,6 @@ class Program(QtWidgets.QMainWindow):
 
     def Send_image(self):
         Buffer_Data = []
-        n = 0
-        m = 64
         for j in range(0, len(self.Image_matrix)):
             decimal = (self.Image_matrix[j])
             print(decimal)

--- a/Python_Interface/Interface.py
+++ b/Python_Interface/Interface.py
@@ -61,6 +61,8 @@ class Program(QtWidgets.QMainWindow):
             "460800"
         ]
 
+        self.ui.Serial_Informmation.setText("Connection state : Disconnect ")
+
         self.ui.ComboBox_BaudRate.addItems(baudrates)
 
         """
@@ -167,27 +169,40 @@ class Program(QtWidgets.QMainWindow):
         """
 
     def Pixel_Converter(self, Pixels):
-        for i in range(0, len(Pixels)):
-            alto, ancho, _ = Pixels[i].shape
-            print(alto, ancho)
+        image_data = {"width" : 0, "height" : 0, "size" : 0}
+        list_data_img = []
+        if len(Pixels)!=0:
+            for t in range(0, len(Pixels)):
+                alto, ancho, _ = Pixels[t].shape
+                image_data["width"] = ancho
+                image_data["height"] = alto
+                image_data["size"] = int((alto * ancho)/256)
+                current_img = Pixels[t]
+                for j in range(0, ancho):
+                    for i in range(0, alto):
+                        Red = int(current_img[i, j, 0])
+                        Green = int(current_img[i, j, 1])
+                        Blue = int(current_img[i, j, 2])
+                        r_5_bits = (Red >> 3) & 0x1F
+                        g_6_bits = (Green >> 2) & 0x3F
+                        b_5_bits = (Blue >> 3) & 0x1F
+                        Final_value = (r_5_bits << 11) | (g_6_bits << 5) | b_5_bits
+                        self.Image_matrix.append(Final_value)
+
+                print(len(self.Image_matrix))
+
+
+
 
         """
         print(alto)
         print(ancho)
-        for j in range(0, ancho):
-            for i in range(0, alto):
-                Red = int(Pixels[i, j, 0])
-                Green = int(Pixels[i, j, 1])
-                Blue = int(Pixels[i, j, 2])
-                r_5_bits = (Red >> 3) & 0x1F
-                g_6_bits = (Green >> 2) & 0x3F
-                b_5_bits = (Blue >> 3) & 0x1F
+        
 
                # print(Red, Green, Blue)
               #  print("Red {} Green {}  Blue {}".format(r_5_bits, g_6_bits, b_5_bits))
               #  print("Red {} Green {}  Blue {}".format(bin(r_5_bits), bin(g_6_bits), bin(b_5_bits)))
-                Final_value = (r_5_bits << 11) | (g_6_bits << 5) | b_5_bits
-                self.Image_matrix.append(Final_value)
+                
       #  print(self.Image_matrix)
         print("Imagen Procesada")
     """
@@ -283,9 +298,8 @@ class Program(QtWidgets.QMainWindow):
 
 
     def Send_test_data(self):
-        a = 'pig'.encode('utf_8')
-        if (self.Serial_state):
-            self.Serial_data.Serial_port.write(a)
+        a = 'Test'.encode('utf_8')
+        self.Serial_data.Serial_port.write(a)
         # Put Image Command
         """
         Buffer_Data = []
@@ -313,12 +327,18 @@ class Program(QtWidgets.QMainWindow):
     def Process_Serial_data(self):
         if (self.Serial_state):
             if(self.data):
-                self.ui.Serial_Informmation.setText(str(self.data[0]))
-                if (self.data[0] == 'Ok'):
+
+                if (self.data and self.data[0] == 'Ok'):
+                    self.ui.Serial_Informmation.setText(str(self.data[0]))
                     a = '064-123-423'.encode('utf_8')
                     self.Serial_data.Serial_port.write(a)
                     self.data = None
                 if(self.data and self.data[0] == "Ready"):
+                    self.ui.Serial_Informmation.setText(str(self.data[0]))
+                    a = 'cr'.encode('utf_8')
+                    self.Serial_data.Serial_port.write(a)
+                if (self.data and self.data[0] == "Okt"):
+                    self.ui.Serial_Informmation.setText("Test Port State : Ok")
                     a = 'cr'.encode('utf_8')
                     self.Serial_data.Serial_port.write(a)
 

--- a/main.c
+++ b/main.c
@@ -74,6 +74,9 @@ Image_data Control_Image;
 
 void Process_Command(unsigned char *buffer)
 {
+    
+    
+     ST7735S_Fill_display(GreenApple_Color); 
     char dataprint[];
     char grupo1[4], grupo2[4], grupo3[4];
     
@@ -120,8 +123,7 @@ void Process_Command(unsigned char *buffer)
               
           }
     
- 
-    
+  
   
     
     
@@ -175,7 +177,11 @@ void Processing_Data(uint8_t Data[])
               __delay_ms(10);
             
             
-            
+             Control_Image.width = 0;//Restart Image width data
+                    Control_Image.height = 0;//Restart Image height data
+                            Control_Image.size = 0;//Restart Image size data
+              
+              
             //Do while cr command is not in the buffer 
             while(readBuffer[0]!=99 || readBuffer[1]!=114)
             {
@@ -212,8 +218,12 @@ void Processing_Data(uint8_t Data[])
       
        if(byte_control > 0)
        { 
-          ST7735S_Fill_display(Orange_Color);  
+          
+          if(Control_Image.width==0 && Control_Image.height==0 &&Control_Image.size==0)
+          {
+              ST7735S_Fill_display(Orange_Color);
           Process_Command(readBuffer); 
+          }
 //            while(readBuffer[idx] != '\0' )
 //            { 
 //                if(readBuffer[idx] >= '0' && readBuffer[idx]<='9')

--- a/main.c
+++ b/main.c
@@ -70,6 +70,8 @@ typedef struct
 
 Image_data Control_Image;
 
+
+
 void Process_Command(unsigned char *buffer)
 {
     char dataprint[];
@@ -100,6 +102,23 @@ void Process_Command(unsigned char *buffer)
           
            sprintf(dataprint, "%d", Control_Image.size);  
           ST7735S_Print_String(Blue_Color, dataprint, 0, 60, 2);
+          
+          if(Control_Image.width!=0 && Control_Image.height!=0 &&Control_Image.size)
+          {
+              
+               //Send Command Ok
+             writeBuffer[0] = 82;//R
+                writeBuffer[1] = 101;//e
+                    writeBuffer[2] = 97;//a
+                        writeBuffer[3] = 100;//d
+                            writeBuffer[4] = 121;//y
+                                writeBuffer[5] = 10;//New Line
+                                    writeBuffer[6] = 13;//CR
+                      putUSBUSART(writeBuffer,6);
+           CDCTxService();
+            
+              
+          }
     
  
     

--- a/main.c
+++ b/main.c
@@ -250,10 +250,19 @@ void Processing_Data(uint8_t Data[])
       
        if(byte_control > 0)
        { 
+           
+           if(transfer_state==WAITING_IMGS_DATA)
+              
+          {
+          Process_Command(readBuffer);
+          transfer_state = SUSPENDED;
+            
+          }
           
            //Si aun no se ha recibido el numero de imagenes a enviar
           if(transfer_state==WAITING_IMGS_NUMBERS)
           {
+              //Se Obtiene el numero de imagenes
               char grupo4[3];
               for(i=0; i<=2; i++)
             {
@@ -263,15 +272,29 @@ void Processing_Data(uint8_t Data[])
               grupo4[2]  = '\0';
               numImgs = atoi(grupo4);//Se obtiene el numero de imagenes a enviar
               
-              if(numImgs !=0 && Control_Image.width==0 && Control_Image.height==0 &&Control_Image.size==0)
+              if(numImgs !=0 )
               {
                   ST7735S_Fill_display(Orange_Color);
                   sprintf(dataprint, "%d", numImgs);  
                  ST7735S_Print_String(Blue_Color, dataprint, 0, 0, 2);
+                 
+                  //Send request wait
+             writeBuffer[0] = 119;
+                writeBuffer[1] = 97;
+                    writeBuffer[2] = 105;
+                        writeBuffer[3] = 116;
+                            writeBuffer[4] = 10;
+                                writeBuffer[5] = 13;
+                    putUSBUSART(writeBuffer,5);
+                    CDCTxService();
+                    transfer_state = WAITING_IMGS_DATA;
+                    
+                       
               }
               
           //Process_Command(readBuffer); 
           }
+          
 //            while(readBuffer[idx] != '\0' )
 //            { 
 //                if(readBuffer[idx] >= '0' && readBuffer[idx]<='9')

--- a/main.c
+++ b/main.c
@@ -155,6 +155,24 @@ void Processing_Data(uint8_t Data[])
             
              
         }
+     
+     //Test Command
+        if(Data[0]==84 && Data[1]==101 && Data[2]==115 && Data[3]==116 )
+            
+        {
+            
+            //Send Command Okt Request Test byte
+             writeBuffer[0] = 79;
+                writeBuffer[1] = 107;
+                    writeBuffer[2] = 116;
+                    writeBuffer[3] = 10;
+                        writeBuffer[4] = 13;
+                    putUSBUSART(writeBuffer,4);
+           CDCTxService();
+            
+            
+        }
+        
         
         
         //pig Command Put image data command


### PR DESCRIPTION
Se realiza el primer envió de datos para la escritura en el Hardware se recibe una sola imagen sin interrupción y perdida de bytes sin embargo, se debe corregir ciertas facultades en el código: 

*Se debe añadir en la matriz de envió de datos la cantidad de todos los bytes de escritura por cada archivo, en el momento solo se envía los datos de un solo paquete.

*El código en la interfaz solamente envía los metadatos correctos cuando las dimensiones de los archivos son inferiores a tamaños 100 de ancho, se debe corregir en código de envió de metadatos.

*Se debe decidir si se envía todos los archivos en un solo ciclo o si se hace en ciclos diferentes.